### PR TITLE
Structured private addresses - fixes #29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ terraform.rc
 
 # Ignore terraform.tfvars since local data is stored there
 **/terraform.tfvars
+**/.terraform.lock.hcl

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,7 +36,10 @@ output private_addresses_new {
   description = "List of BIG-IP private addresses"
   value       = {
     mgmt              = length(compact(local.mgmt_public_private_ip_primary)) > 0 ? aws_network_interface.mgmt.*.private_ips :aws_network_interface.mgmt1.*.private_ips
-    public            = length(compact(local.external_public_private_ip_primary)) > 0 ? aws_network_interface.public.*.private_ips : aws_network_interface.public1.*.private_ips
+    public            = {
+      private_ip  = length(compact(local.external_public_private_ip_primary)) > 0 ? aws_network_interface.public.*.private_ip : aws_network_interface.public1.*.private_ip
+      private_ips = length(compact(local.external_public_private_ip_primary)) > 0 ? aws_network_interface.public.*.private_ips : aws_network_interface.public1.*.private_ips
+    }
     external_private  = length(compact(local.external_private_ip_primary)) > 0 ? aws_network_interface.external_private.*.private_ips : aws_network_interface.external_private1.*.private_ips
     private           = length(compact(local.internal_private_ip_primary)) > 0 ? aws_network_interface.private.*.private_ips : aws_network_interface.private1.*.private_ips
   }  

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,6 +32,20 @@ output private_addresses {
   value       = concat(aws_network_interface.mgmt.*.private_ips, aws_network_interface.mgmt1.*.private_ips, aws_network_interface.public.*.private_ips, aws_network_interface.external_private.*.private_ips, aws_network_interface.private.*.private_ips, aws_network_interface.public1.*.private_ips, aws_network_interface.external_private1.*.private_ips, aws_network_interface.private1.*.private_ips)
 }
 
+output private_addresses_new {
+  description = "List of BIG-IP private addresses"
+  value       = {
+    mgmt              = aws_network_interface.mgmt.*.private_ips
+    mgmt1             = aws_network_interface.mgmt1.*.private_ips
+    public            = aws_network_interface.public.*.private_ips
+    external_private  = aws_network_interface.external_private.*.private_ips
+    private           = aws_network_interface.private.*.private_ips
+    public1           = aws_network_interface.public1.*.private_ips
+    external_private1 = aws_network_interface.external_private1.*.private_ips
+    private1          = aws_network_interface.private1.*.private_ips
+  }  
+}
+
 output public_addresses {
   description = "List of BIG-IP public addresses"
   value       = concat(aws_eip.ext-pub.*.public_ip)

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,13 +35,22 @@ output private_addresses {
 output private_addresses_new {
   description = "List of BIG-IP private addresses"
   value       = {
-    mgmt              = length(compact(local.mgmt_public_private_ip_primary)) > 0 ? aws_network_interface.mgmt.*.private_ips :aws_network_interface.mgmt1.*.private_ips
-    public            = {
+    mgmt              = {
+      private_ip  = length(compact(local.mgmt_public_private_ip_primary)) > 0 ? aws_network_interface.mgmt.*.private_ip :aws_network_interface.mgmt1.*.private_ip
+      private_ips = length(compact(local.mgmt_public_private_ip_primary)) > 0 ? aws_network_interface.mgmt.*.private_ips :aws_network_interface.mgmt1.*.private_ips
+    }
+    public      = {
       private_ip  = length(compact(local.external_public_private_ip_primary)) > 0 ? aws_network_interface.public.*.private_ip : aws_network_interface.public1.*.private_ip
       private_ips = length(compact(local.external_public_private_ip_primary)) > 0 ? aws_network_interface.public.*.private_ips : aws_network_interface.public1.*.private_ips
     }
-    external_private  = length(compact(local.external_private_ip_primary)) > 0 ? aws_network_interface.external_private.*.private_ips : aws_network_interface.external_private1.*.private_ips
-    private           = length(compact(local.internal_private_ip_primary)) > 0 ? aws_network_interface.private.*.private_ips : aws_network_interface.private1.*.private_ips
+    external_private  = {
+      private_ip  = length(compact(local.external_private_ip_primary)) > 0 ? aws_network_interface.external_private.*.private_ip : aws_network_interface.external_private1.*.private_ip
+      private_ips = length(compact(local.external_private_ip_primary)) > 0 ? aws_network_interface.external_private.*.private_ips : aws_network_interface.external_private1.*.private_ips
+    }
+    private           = {
+      private_ip  = length(compact(local.internal_private_ip_primary)) > 0 ? aws_network_interface.private.*.private_ip : aws_network_interface.private1.*.private_ip
+      private_ips = length(compact(local.internal_private_ip_primary)) > 0 ? aws_network_interface.private.*.private_ips : aws_network_interface.private1.*.private_ips
+    }
   }  
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -42,8 +42,6 @@ output private_addresses_new {
   }  
 }
 
-length(compact(local.external_public_private_ip_primary)) > 0
-
 output public_addresses {
   description = "List of BIG-IP public addresses"
   value       = concat(aws_eip.ext-pub.*.public_ip)

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,16 +35,14 @@ output private_addresses {
 output private_addresses_new {
   description = "List of BIG-IP private addresses"
   value       = {
-    mgmt              = aws_network_interface.mgmt.*.private_ips
-    mgmt1             = aws_network_interface.mgmt1.*.private_ips
-    public            = aws_network_interface.public.*.private_ips
-    external_private  = aws_network_interface.external_private.*.private_ips
-    private           = aws_network_interface.private.*.private_ips
-    public1           = aws_network_interface.public1.*.private_ips
-    external_private1 = aws_network_interface.external_private1.*.private_ips
-    private1          = aws_network_interface.private1.*.private_ips
+    mgmt              = length(compact(local.mgmt_public_private_ip_primary)) > 0 ? aws_network_interface.mgmt.*.private_ips :aws_network_interface.mgmt1.*.private_ips
+    public            = length(compact(local.external_public_private_ip_primary)) > 0 ? aws_network_interface.public.*.private_ips : aws_network_interface.public1.*.private_ips
+    external_private  = length(compact(local.external_private_ip_primary)) > 0 ? aws_network_interface.external_private.*.private_ips : aws_network_interface.external_private1.*.private_ips
+    private           = length(compact(local.internal_private_ip_primary)) > 0 ? aws_network_interface.private.*.private_ips : aws_network_interface.private1.*.private_ips
   }  
 }
+
+length(compact(local.external_public_private_ip_primary)) > 0
 
 output public_addresses {
   description = "List of BIG-IP public addresses"


### PR DESCRIPTION
This addresses the inconsistency issue in #29 by creating a structured output.

The output is currently called private_addresses_new in order to avoid breaking dependencies on the existing output. A better output name is warranted.

The output structure is
BIG-IP
 - mgmt
   - private_ip
   - private_ips
  - public
    - private_ip
    - private_ips
  - external_private
    - private_ip
    - private_ips
  -  private
     - private_ip
     - private_ips

The ```private_ip``` attribute consistently contains the primary IP address of the nic.

The ```private_ips``` attribute is a list of all private IP addresses on the nic, including the primary