### PR TITLE
arbitrary map of tags for generated resources FIXES #11

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -177,3 +177,9 @@ variable custom_user_data {
   type        = string
   default     = null
 }
+
+variable tags {
+  description = "key:value tags to apply to resources built by the module"
+  type        = map
+  default     = {}
+}


### PR DESCRIPTION
Add an input variable "tags" to pass in key-value pairs as a map. The tags are applied to all resources generated by the module. The map of tags is merged with any existing resource-specific tags (e.g. Name). The input variable has a default value of an empty map (i.e. '{]' )

This PR has been successfully tested without the tags input variable and with a set of arbitrary key-value pairs to build a BIG-IP with TMOS 15.1.4. 

Profile: BIG-IP Automation Toolchain readiness (bigip-ready)
Version: 0.1.0
Target:  local://

  ✔  bigip-connectivity: BIG-IP is reachable
     ✔  Host x.x.x.x port 443 proto tcp is expected to be reachable
  ✔  bigip-declarative-onboarding: BIG-IP has Declarative Onboarding
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/shared/declarative-onboarding/info status is expected to cmp == 200
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/shared/declarative-onboarding/info headers.Content-Type is expected to match "application/json"
  ✔  bigip-declarative-onboarding-version: BIG-IP has specified version of Declarative Onboarding
     ✔  JSON content [0, "version"] is expected to eq "1.21.0"
  ✔  bigip-application-services: BIG-IP has Application Services
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/shared/appsvcs/info status is expected to cmp == 200
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/shared/appsvcs/info headers.Content-Type is expected to match "application/json"
  ✔  bigip-application-services-version: BIG-IP has specified version of Application Services
     ✔  JSON content version is expected to eq "3.28.0"
  ✔  bigip-telemetry-streaming: BIG-IP has Telemetry Streaming
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/shared/telemetry/info status is expected to cmp == 200
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/shared/telemetry/info headers.Content-Type is expected to match "application/json"
  ✔  bigip-telemetry-streaming-version: BIG-IP has specified version of Telemetry Streaming
     ✔  JSON content version is expected to eq "1.20.0"
  ✔  bigip-licensed: BIG-IP has an active license
     ✔  HTTP GET on https://x.x.x.x:443/mgmt/tm/sys/license body is expected to match /registrationKey/


Profile: bigip Kitchen-Terraform (bigip)
Version: 0.1.0
Target:  local://

  ✔  bigip-postbuildconfig-do-self: expected selfIps
     ✔  JSON content address is expected to cmp == "10.20.0.9/24"
     ✔  JSON content vlan is expected to cmp == "/Common/external"
     ✔  JSON content allowService is expected to cmp == "tcp:443"
     ✔  JSON content address is expected to cmp == "10.30.0.10/24"
     ✔  JSON content vlan is expected to cmp == "/Common/internal"
     ✔  JSON content allowService is expected to cmp == "default"
  ✔  bigip-postbuildconfig-do-dns: expected dns
     ✔  JSON content nameServers is expected to cmp == "8.8.8.8"
  ✔  bigip-postbuildconfig-do-vlan: expected vlans
     ✔  JSON content tag is expected to cmp == "10"
     ✔  JSON content mtu is expected to cmp == "1500"
     ✔  JSON content tag is expected to cmp == "20"
     ✔  JSON content mtu is expected to cmp == "1500"
  ✔  bigip-postbuildconfig-do-provision: expected provisioning
     ✔  JSON content level is expected to cmp == "nominal"
     ✔  JSON content level is expected to cmp == "nominal"